### PR TITLE
add setup.py for pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from setuptools import setup, find_packages
+
+setup(
+    name='BOSCH-GLM-rangefinder',
+    version='0.0',
+    author='philipptrenz',
+    author_email='mail@philipptrenz.de',
+    description='Remote control a BOSCH GLM 100C rangefinder via its Bluetooth serial interface.',
+    url='https://github.com/philipptrenz/BOSCH-GLM-rangefinder',
+    install_requires=[
+        'PyBluez==0.22',
+    ],
+)


### PR DESCRIPTION
This file allow install BOSCH-GLM-rangefinder via pip.