### PR TITLE
fix: Add requests library to install requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     url='https://github.com/philipptrenz/BOSCH-GLM-rangefinder',
     install_requires=[
         'PyBluez==0.22',
+        'requests==2.22.0',
     ],
 )


### PR DESCRIPTION
Now, with GLM50C support added, 'requests' library is needed for catch some
exceptions.